### PR TITLE
Fixed the entrypoint sessionCookieSecure env var

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,7 @@ printf '{
     "serverPort": 9000,
 
     "sessionSecret": "'${SESSION_SECRET}'",
-    "sessionCookieSecure": "'${SESSION_COOKIE_SECURE}'",
+    "sessionCookieSecure": '${SESSION_COOKIE_SECURE:-true}',
 
     "oidc": {
         "issuer": "'${OIDC_ISSUER}'",


### PR DESCRIPTION
My previous fix in 1c15f63be87cd33a0f2ea8d13e9f04beb502de71 incorrectly changing from boolean to string